### PR TITLE
fix typo

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -36,7 +36,7 @@ const assertType = <T>() => <U extends T>(x: U): U => {
   return x
 }
 
-// omitting return type annotaton to verify type inferecne here
+// omitting return type annotation to verify type inference here
 const createSimplePerson = (type: 'dev' | 'ui/ux') =>
   match(type, {
     dev: () =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ type Matchers<
         x: TaggedUnionExtract<TaggedUnion, TagName, Tag>,
       ) => any
       // "_" (underscore) here is intentionally not using constant like `const DEFAULT_CASE_NAME = "_"` to avoid string like "DEFAULT_CASE_NAME" as a part of TypeScript error to users
-      // TODO `x` shold be refined to be unspesified variants rather than the whole TaggedUnion type
+      // TODO `x` should be refined to be unspecified variants rather than the whole TaggedUnion type
     } & { _: (x: TaggedUnion) => any })
 
 export function match<


### PR DESCRIPTION
VSCode extension "Code Spell Checker" is a good friend.